### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ React boilerplate for building applications based on the Spotify Web API. The ex
 * [React Spotify Api](https://idanlo.github.io/react-spotify-api/)
 
 ## Authorization
-The boilerplate uses OAuth 2.0 implicit grant flow which is for clients that are implemented entirely using JavaScript and running in the resource owner’s browser. [Register your app](https://developer.spotify.com/documentation/general/guides/app-settings/#register-your-app) to receive a client id which should be placed in `src/auth/configuration.ts`.
+The boilerplate uses OAuth 2.0 implicit grant flow which is for clients that are implemented entirely using JavaScript and running in the resource owner’s browser. [Register your app](https://developer.spotify.com/documentation/general/guides/app-settings/#register-your-app) to receive a client id.  The `src/auth/configuration.ts` is set up to read from a `.env` file, which needs to be populated with the client id and the callback uri.  Callback uri must also be set on the spotify developer page.
 
 ![Spotify Implicit Grant Flow](AuthG_ImplicitGrant.png "Spotify Implicit Grant Flow")
 


### PR DESCRIPTION
Documentation is not clear enough for people using oauth2 / spotify api for the first time.  A good boilerplate should work with minimal configuration, and the configuration that is necessary should be plainly documented.  

I was unable to get the app to work until I added a callback uri in the spotify developer panel.  I think this change to the README will help others who have the same problem.